### PR TITLE
Use @BaseView and @FullView on methods

### DIFF
--- a/src/main/java/com/github/bohnman/squiggly/view/BaseView.java
+++ b/src/main/java/com/github/bohnman/squiggly/view/BaseView.java
@@ -5,13 +5,14 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Convenience annotation indicating that a field belong to the "base" view.  This annotation is generally
  * not needed because a non-annotated implictly belongs to the "base" view.
  */
-@Target(FIELD)
+@Target({FIELD, METHOD})
 @Retention(RUNTIME)
 @Documented
 @PropertyView(PropertyView.BASE_VIEW)

--- a/src/main/java/com/github/bohnman/squiggly/view/FullView.java
+++ b/src/main/java/com/github/bohnman/squiggly/view/FullView.java
@@ -5,12 +5,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Convenience annotation that indicates the field belongs to the "full" view.
  */
-@Target(FIELD)
+@Target({FIELD, METHOD})
 @Retention(RUNTIME)
 @Documented
 @PropertyView(PropertyView.FULL_VIEW)


### PR DESCRIPTION
`@BaseView` and `@FullView` should be allowed on getter methods because they are part of the serialisation process.

`@PropertyView` is already allowed on methods, therefore putting `@BaseView` or `@FullView` on a method is syntactic sugar for `@PropertyView(PropertyView.BASE_VIEW)` or `@PropertyView(PropertyView.FULL_VIEW)`.

For `@BaseView`, this will mostly be useful when `property.addNonAnnotatedFieldsToBaseView=false` in squiggly.properties because otherwise any getter method will be part of the base view automatically.